### PR TITLE
add user groups Employee and Admin

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -82,18 +82,13 @@
     -> "dct:created"
     -> "dct:modified"))
 
+(define-graph groups ("http://mu.semte.ch/graphs/users")
+  ("foaf:Group")
+)
 ;;;;;;;;;;;;;
 ;; User roles
 
 (supply-allowed-group "public")
-
-(grant (read write)
-       :to-graph timesheet
-       :for-allowed-group "public")
-
-(grant (read)
-       :to-graph (static)
-       :for-allowed-group "public")
 
 (with-scope "http://services.redpencil.io/timekeeper-kimai-sync-service"
   (grant (read write)
@@ -110,9 +105,41 @@
           <SESSION_ID> session:account ?account .
       } LIMIT 1")
 
-(grant (write)
-       :to-graph timesheet
-       :for-allowed-group "logged-in")
+(supply-allowed-group "admin"
+  :parameters ()
+  :query "PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      SELECT ?account WHERE {
+          <SESSION_ID> session:account ?account .
+          ?user foaf:account ?account .
+          <http://mu.semte.ch/user-groups/admin> foaf:member ?user .
+      } LIMIT 1")
+
+
+(supply-allowed-group "employee"
+  :parameters ()
+  :query "PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      SELECT ?account WHERE {
+          <SESSION_ID> session:account ?account .
+          ?user foaf:account ?account .
+          <http://mu.semte.ch/user-groups/employee> foaf:member ?user .
+      } LIMIT 1")
+
+(grant (read write)
+       :to-graph (timesheet)
+       :for-allowed-group "employee")
+
 (grant (read)
-       :to-graph (kimai static users)
+       :to-graph (static)
        :for-allowed-group "logged-in")
+
+(grant (read)
+       :to-graph (users)
+       :for-allowed-group "logged-in")
+
+(grant (read write)
+       :to-graph (groups)
+       :for-allowed-group "admin")

--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -81,17 +81,13 @@
     -> "foaf:accountServiceHomepage"
     -> "dct:created"
     -> "dct:modified")
-  ("foaf:Group"))
+  ("foaf:Group"
+    -> "foaf:member"))
+
 ;;;;;;;;;;;;;
 ;; User roles
 
 (supply-allowed-group "public")
-
-(with-scope "http://services.redpencil.io/timekeeper-kimai-sync-service"
-  (grant (read write)
-    :to-graph (kimai)
-    :for-allowed-group "public"))
-
 
 (supply-allowed-group "logged-in"
   :parameters ()
@@ -124,6 +120,15 @@
           ?user foaf:account ?account .
           <http://mu.semte.ch/user-groups/employee> foaf:member ?user .
       } LIMIT 1")
+
+(grant (read)
+       :to-graph (static)
+       :for-allowed-group "public")
+
+(with-scope "http://services.redpencil.io/timekeeper-kimai-sync-service"
+  (grant (read write)
+    :to-graph (kimai timesheet)
+    :for-allowed-group "public"))
 
 (grant (read write)
        :to-graph (timesheet)

--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -80,11 +80,8 @@
     -> "foaf:accountName"
     -> "foaf:accountServiceHomepage"
     -> "dct:created"
-    -> "dct:modified"))
-
-(define-graph groups ("http://mu.semte.ch/graphs/users")
-  ("foaf:Group")
-)
+    -> "dct:modified")
+  ("foaf:Group"))
 ;;;;;;;;;;;;;
 ;; User roles
 
@@ -141,5 +138,5 @@
        :for-allowed-group "logged-in")
 
 (grant (read write)
-       :to-graph (groups)
+       :to-graph (users)
        :for-allowed-group "admin")

--- a/config/migrations/20241206141100-user-groups-employee-admin.sparql
+++ b/config/migrations/20241206141100-user-groups-employee-admin.sparql
@@ -1,0 +1,13 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/users> {
+    <http://mu.semte.ch/user-groups/employee> a foaf:Group ;
+        mu:uuid "cb3222fd-3e1d-4239-9c1b-62cc3d211645" ;
+        foaf:name "Employee" .
+
+    <http://mu.semte.ch/user-groups/admin> a foaf:Group ;
+        mu:uuid "40251108-3b5c-4dce-b14a-f0d0c8947237" ;
+        foaf:name "Admin" .
+  }
+}


### PR DESCRIPTION
add two user-groups in a migration.
Updates the authorization config to an initial version. This will need an update depending on who can view what in the frontend. 

Note: You'll need to add these user-groups to your test user.

Do this with:
``` 
INSERT DATA {
	GRAPH <> {
		<http://mu.semte.ch/user-groups/admin> foaf:member <person_uri> .
		<http://mu.semte.ch/user-groups/employee> foaf:member <person_uri> .
    }
}
```
With `<person_uri>` the predicate of type `foaf:person`, *not* `foaf:OnlineAccount`.