### PR TITLE
add configuration to allow linking accounts to users

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -128,6 +128,9 @@
 (with-scope "http://services.redpencil.io/timekeeper-kimai-sync-service"
   (grant (read write)
     :to-graph (kimai timesheet)
+    :for-allowed-group "public")
+  (grant (read)
+    :to-graph (users)
     :for-allowed-group "public"))
 
 (grant (read write)

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -61,11 +61,15 @@ defmodule Dispatcher do
     forward conn, path, "http://resource/timesheets/"
   end
 
-  get "/persons/*path", %{ layer: :services, accept: %{ json: true } } do
-    forward conn, path, "http://resource/persons/"
+  get "/people/*path", %{ layer: :services, accept: %{ json: true } } do
+    forward conn, path, "http://resource/people/"
   end
 
-  get "/accounts/*path", %{ layer: :services, accept: %{ json: true } } do
+  get "/user-groups/*path", %{ layer: :services, accept: %{ json: true } } do
+    forward conn, path, "http://resource/user-groups/"
+  end
+
+  match "/accounts/*path", %{ layer: :services, accept: %{ json: true } } do
     forward conn, path, "http://resource/accounts/"
   end
 

--- a/config/migrations/20241223111235-ensure-homepage-on-all-user-accounts.sparql
+++ b/config/migrations/20241223111235-ensure-homepage-on-all-user-accounts.sparql
@@ -1,0 +1,12 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/users> {
+    ?account <http://xmlns.com/foaf/0.1/accountServiceHomepage> <http://timekeeper.redpencil.io> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/users> {
+    ?account a <http://xmlns.com/foaf/0.1/OnlineAccount> .
+    FILTER NOT EXISTS {
+      ?account <http://xmlns.com/foaf/0.1/accountServiceHomepage> ?homepage .
+    }
+  }
+}

--- a/config/resources/users.json
+++ b/config/resources/users.json
@@ -75,7 +75,7 @@
         }
       },
       "relationships": {
-        "persons": {
+        "members": {
           "predicate": "foaf:member",
           "target": "person",
           "cardinality": "many"

--- a/config/resources/users.json
+++ b/config/resources/users.json
@@ -4,7 +4,7 @@
     "foaf": "http://xmlns.com/foaf/0.1/"
   },
   "resources": {
-    "persons": {
+    "people": {
       "name": "person",
       "class": "foaf:Person",
       "attributes": {
@@ -14,11 +14,6 @@
         }
       },
       "relationships": {
-        "account": {
-          "predicate": "foaf:account",
-          "target": "account",
-          "cardinality": "many"
-        },
         "work-logs": {
           "predicate": "prov:wasAssociatedWith",
           "target": "work-log",
@@ -30,6 +25,17 @@
           "target": "timesheet",
           "cardinality": "many",
           "inverse": true
+        },
+        "user-groups": {
+          "predicate": "foaf:member",
+          "target": "user-group",
+          "cardinality": "many",
+          "inverse": true
+        },
+        "accounts": {
+          "predicate": "foaf:account",
+          "target": "account",
+          "cardinality": "many"
         }
       },
       "features": ["include-uri"],
@@ -43,8 +49,8 @@
           "type": "string",
           "predicate": "foaf:accountName"
         },
-        "account-service-url": {
-          "type": "string",
+        "account-service-homepage": {
+          "type": "url",
           "predicate": "foaf:accountServiceHomepage"
         }
       },
@@ -58,6 +64,25 @@
       },
       "features": ["include-uri"],
       "new-resource-base": "http://timekeeper.redpencil.io/accounts/"
+    },
+    "user-groups": {
+      "name": "user-group",
+      "class": "foaf:Group",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "foaf:name"
+        }
+      },
+      "relationships": {
+        "persons": {
+          "predicate": "foaf:member",
+          "target": "person",
+          "cardinality": "many"
+        }
+      },
+      "features": ["include-uri"],
+      "new-resource-base": "http://timekeeper.redpencil.io/user-groups/"
     }
   }
 }


### PR DESCRIPTION
These configuration changes are needed to link kimai accounts to people in the frontend: https://github.com/redpencilio/frontend-timekeeper/pull/2

- add extra dispatcher routes to allow frontend to read/write accounts + fix fetching of info of persons and user-groups (note that the frontend will send a request to `/people`, not `/persons`, as the used json-api adapter will do smart pluralization).
- make the accounts relationship explicitely plural
- make the homepage a "url" type. This is needed as the kimai-sync service adds the homepage as a uri, not a "uri in a string"
