### PR TITLE
Add admin-jobs service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,3 +85,7 @@ services:
       - database:database
     labels:
       - "logging=true"
+  admin-jobs:
+    image: redpencil/timekeeper-admin-jobs-service:0.1.0
+    environment:
+      PUBLIC_HOLIDAY_TASK: "http://timekeeper.redpencil.io/tasks/holiday-task" # TODO adjust to correct uri


### PR DESCRIPTION
needs release of https://github.com/redpencilio/timekeeper-admin-jobs-service

The public holiday uri still has to be set correctly for the demo/production database.

Alternatively, set it in .override (and .dev)
or create a migration to give this task a specific uri (which would need to be done via some string matching of the name of the task?)